### PR TITLE
add travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 sudo: required
 language: generic
-script: wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.38.5/propelleride-0.38.5-amd64.deb && dpkg install propelleride-0.38.5-amd64.deb
+script: wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.38.5/propelleride-0.38.5-amd64.deb && dpkg -i propelleride-0.38.5-amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ addons:
 script:
   - wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.38.5/propelleride-0.38.5-amd64.deb
   - sudo dpkg -i propelleride-0.38.5-amd64.deb
+  - /usr/bin/openspin -L /usr/bin/../share/propelleride/library JTAGulator.spin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 language: generic
 script:
   - wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.38.5/propelleride-0.38.5-amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+sudo: required
+language: generic
+script: wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.38.5/propelleride-0.38.5-amd64.deb && dpkg install propelleride-0.38.5-amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
   apt:
     packages:
       - qt5-default
+      - libqt5serialport5
       - libftdi1
 script:
   - wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.38.5/propelleride-0.38.5-amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 sudo: required
 language: generic
-script: wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.38.5/propelleride-0.38.5-amd64.deb && dpkg -i propelleride-0.38.5-amd64.deb
+script:
+  - wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.38.5/propelleride-0.38.5-amd64.deb
+  - sudo dpkg -i propelleride-0.38.5-amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: required
 dist: trusty
 language: generic
+addons:
+  apt:
+    packages:
+      - qt5-default
+      - libftdi1
 script:
   - wget https://github.com/parallaxinc/PropellerIDE/releases/download/0.38.5/propelleride-0.38.5-amd64.deb
   - sudo dpkg -i propelleride-0.38.5-amd64.deb


### PR DESCRIPTION
sets up propelleride and compiles jtagulator

could also be used for continuous deployment, moving `Jtagulator.eeprom` binary to the github releases area and out of the repo