### PR TITLE
Add initial Serial Wire Debug (SWD) support

### DIFF
--- a/JTAGulator.spin
+++ b/JTAGulator.spin
@@ -57,6 +57,7 @@ CON
   MENU_JTAG     = 1    ' JTAG
   MENU_UART     = 2    ' UART
   MENU_GPIO     = 3    ' General Purpose I/O
+  MENU_SWD      = 4    ' Serial Wire Debug (SWD)
    
   
 VAR                   ' Globally accessible variables
@@ -91,7 +92,12 @@ VAR                   ' Globally accessible variables
   long uStack[50]     ' Stack space for passthrough cog
 
   long gWriteValue    ' Parameter for Write_IO_Pins
-  
+ 
+  long swdClk         ' SWD Pins (must stay in this order)
+  long swdIo
+  long swdPinsKnown   ' Are above pins valid?
+  long swdFrequency
+   
   long chStart        ' Channel range for the current scan (specified by the user)
   long chEnd
   
@@ -107,6 +113,7 @@ OBJ
   uart          : "JDCogSerial"       ' UART/Asynchronous Serial communication engine (Carl Jacobs, http://obex.parallax.com/object/298)
   pt_in         : "jm_rxserial"       ' UART/Asynchronous Serial receive driver for passthrough (JonnyMac, https://forums.parallax.com/discussion/114492/prop-baudrates)
   pt_out        : "jm_txserial"       ' UART/Asynchronous Serial transmit driver for passthrough (JonnyMac, https://forums.parallax.com/discussion/114492/prop-baudrates)
+  swd           : "SWDHost"           ' SWD Host module  
     
   
 PUB main | cmd
@@ -114,6 +121,7 @@ PUB main | cmd
   JTAG_Init                     ' Initialize JTAG-specific items
   UART_Init                     ' Initialize UART-specific items
   GPIO_Init                     ' Initialize GPIO-specific items
+  SWD_Init                      ' Initialize SWD-specific items
 
   pst.CharIn                    ' Wait until the user presses a key before getting started
   pst.Str(@InitHeader)          ' Display header
@@ -142,6 +150,9 @@ PUB main | cmd
 
         MENU_GPIO:                    ' General Purpose I/O
           Do_GPIO_Menu(cmd)
+          
+        MENU_SWD:                     ' Single Wire Debug
+          Do_SWD_Menu(cmd)
 
         other:
           idMenu := MENU_MAIN
@@ -163,6 +174,9 @@ PRI Do_Main_Menu(cmd)
 
     "G", "g":                 ' Switch to GPIO submenu
       idMenu := MENU_GPIO
+
+    "S", "s":                 ' Switch to SWD submenu
+      idMenu := MENU_SWD
 
     "V", "v":                 ' Set target I/O voltage
       Set_Target_IO_Voltage
@@ -270,6 +284,21 @@ PRI Do_GPIO_Menu(cmd)
       Do_Shared_Menu(cmd)
 
 
+PRI Do_SWD_Menu(cmd)
+  case cmd
+    "I", "i":                 ' Identify SWD pinout (IDCODE Scan)
+      if (vTargetIO == -1)
+        pst.Str(@ErrTargetIOVoltage)
+      else
+        SWD_IDCODE_Scan
+
+    "C", "c":
+      Set_SWD_Frequency
+
+    other:
+      Do_Shared_Menu(cmd)
+                  
+
 PRI Do_Shared_Menu(cmd)
   case cmd
     "V", "v":                 ' Set target I/O voltage
@@ -298,6 +327,9 @@ PRI Display_Menu_Text
 
     MENU_GPIO:
       pst.Str(@MenuGPIO)
+      
+    MENU_SWD:
+      pst.Str(@MenuSWD)
 
   if (idMenu <> MENU_MAIN)
     pst.Str(@MenuShared)
@@ -317,6 +349,9 @@ PRI Display_Command_Prompt
 
     MENU_GPIO:             ' General Purpose I/O
       pst.Str(String("GPIO"))
+      
+    MENU_SWD:              ' Single Wire Debug
+      pst.Str(String("SWD"))
 
     other:
       idMenu := MENU_MAIN
@@ -1732,6 +1767,122 @@ PRI Display_IO_Pins(value) | count
   pst.Str(String(" (0x"))
   pst.Hex(value, g#MAX_CHAN >> 2)
   pst.Str(String(")"))
+  
+       
+CON {{ SWD METHODS }}
+
+PRI SWD_Init
+  ' Don't know any SWD pins yet.
+  swdPinsKnown := 0
+  swdClk := -1
+  swdIo := -1
+  swdFrequency := swd#SWD_FASTEST_CLOCK_RATE
+
+
+PRI SWD_IDCODE_Scan | response, idcode, ctr, num, xclk, xio     ' Identify SWD pinout (IDCODE Scan)
+  if (Get_Channels(2) == -1)   ' Get the channel range to use
+    return
+  Display_Permutations((chEnd - chStart + 1), 2)  ' SWCLK, SWDIO
+
+  if (Get_Settings == -1)      ' Get configurable scan settings
+    return
+    
+  pst.Str(@MsgPressSpacebarToBegin)
+  if (pst.CharIn <> " ")
+    pst.Str(@ErrIDCODEAborted)
+    return
+
+  pst.Str(@MsgJTAGulating)
+  u.TXSEnable   ' Enable level shifter outputs
+  if (jPinsLow == 1)
+    u.Set_Pins_Low(chStart, chEnd)  ' Set current channel range to output LOW
+    u.Pause(jPinsLowDelay)          ' Delay to stay asserted
+         
+  swd.init
+  num := 0      ' Counter of possibly good pinouts
+  ctr := 0      ' Counter of total loop iterataions.
+  repeat swdClk from chStart to chEnd   ' For every possible pin permutation
+    repeat swdIo from chStart to chEnd
+      if (swdIo == swdClk)
+        next
+
+      if (pst.RxEmpty == 0)  ' Abort scan if any key is pressed
+        SWD_Scan_Cleanup(num, xclk, xio)
+        pst.RxFlush
+        pst.Str(@ErrIDCODEAborted)
+        return
+
+      u.Set_Pins_High(chStart, chEnd)       ' Set current channel range to output HIGH (in case there are active low signals that may affect operation, like TRST# or SRST#)  
+      if (jPinsLow == 1)
+        u.Pause(jPinsHighDelay)               ' Delay after deassertion before proceeding 
+
+      ' Use this pin mapping with the SWD module to attempt line resetting the device
+      ' and reading out the IDCODE register.
+      swd.config(swdClk, swdIo, swdFrequency)
+      response := swd.resetSwJtagAndReadIdCode(@idcode)
+
+      ' The IDCODE was most likely read out successfully with this pin mapping if
+      ' the response code is OK (%001) and the least significant bit of the returned
+      ' IDCODE is 1 (unless all bits of IDCODE are 1 which isn't valid).
+      if (response == swd#RESP_OK) and (idcode <> -1) and (idcode & 1)
+        Display_SWD_Pins
+        ' Track this most recent detection results.
+        num++
+        xclk := swdClk
+        xio := swdIo
+        Display_Device_ID(idcode, 0, 0)
+        pst.Str(String(CR, LF))
+          
+      ' Progress indicator
+      ++ctr
+      if (jPinsLow == 0)
+        Display_Progress(ctr, 100)
+      else
+        Display_Progress(ctr, 1) 
+        u.Set_Pins_Low(chStart, chEnd)  ' Set current channel range to output LOW
+        u.Pause(jPinsLowDelay)          ' Delay to stay asserted
+
+  if (num == 0)
+    pst.Str(@ErrNoDeviceFound)  
+  SWD_Scan_Cleanup(num, xclk, xio)
+  
+  pst.Str(String(CR, LF, "IDCODE scan complete."))
+
+
+PRI SWD_Scan_Cleanup(num, clk, io)
+  swd.uninit
+  if (num == 0)    ' If no device(s) were found during the search
+    longfill(@swdClk, -1, 2)  ' Clear SWD pinout
+    swdPinsKnown := 0 
+  else             ' Update globals with the most recent detection results
+    swdClk := clk
+    swdIo := io
+    swdPinsKnown := 1
+
+    
+PRI Display_SWD_Pins
+  pst.Str(String(CR, LF, "SWCLK: "))
+  pst.Dec(swdClk)
+  pst.Str(String(CR, LF, "SWDIO: "))
+  pst.Dec(swdIO)
+  pst.Str(String(CR, LF))
+
+
+PRI Set_SWD_Frequency | value
+  pst.Str(String(CR, LF, "Current SWD clock frequency (Hz): "))
+  pst.Dec(swdFrequency)
+  
+  pst.Str(String(CR, LF, "Enter new SWD clock frequency: "))
+  value := Get_Decimal_Pin
+  
+  if (value < 1 OR value > swd#SWD_FASTEST_CLOCK_RATE)
+    pst.Str(@ErrOutOfRange)
+  else
+    swdFrequency := value
+    pst.Str(String(CR, LF, "New SWD clock frequency set: "))
+    pst.Dec(swdFrequency)
+
+
 
   
 CON {{ OTHER METHODS }}
@@ -2006,7 +2157,8 @@ VersionInfo   byte CR, LF, "JTAGulator FW 1.6", CR, LF
 MenuMain      byte CR, LF, "Target Interfaces:", CR, LF
               byte "J   JTAG/IEEE 1149.1", CR, LF
               byte "U   UART/Asynchronous Serial", CR, LF
-              byte "G   GPIO", CR, LF, LF
+              byte "G   GPIO", CR, LF
+              byte "S   SWD", CR, LF, LF
               byte "General Commands:", CR, LF
               byte "V   Set target I/O voltage (1.2V to 3.3V)", CR, LF
               byte "I   Display version information", CR, LF
@@ -2031,6 +2183,10 @@ MenuGPIO      byte CR, LF, "GPIO Commands:", CR, LF
               byte "C   Read all channels (input, continuous)", CR, LF  
               byte "W   Write all channels (output)", 0
                           
+MenuSWD       byte CR, LF, "SWD Commands:", CR, LF
+              byte "I   Identify SWD pinout (IDCODE Scan)", CR, LF
+              byte "C   Set SWD clock frequency", 0
+
 MenuShared    byte CR, LF, LF, "General Commands:", CR, LF
               byte "V   Set target I/O voltage (1.2V to 3.3V)", CR, LF
               byte "H   Display available commands", CR, LF

--- a/SWDCapture.spin
+++ b/SWDCapture.spin
@@ -1,0 +1,100 @@
+{
+    MIT License
+    
+    Copyright (C) 2019  Adam Green (https://github.com/adamgreen)
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+}
+' SWDCapture - Module to capture SWDIO output on SWCLK rising edges.
+
+CON
+    ' Maximum number of longs to capture in m_buffer.
+    MAX_CAPTURE_LONGS = 4
+    MAX_CAPTURE_BITS = MAX_CAPTURE_LONGS * 32
+    
+    
+VAR
+    ' Pin configuration.
+    BYTE m_swclkPin
+    BYTE m_swdioPin
+
+    ' Buffer to contain captured SWDIO output.
+    LONG m_buffer[MAX_CAPTURE_LONGS]
+    
+    ' Number of rising edges detected on SWCLK pin.
+    LONG m_clockCount
+    
+    ' Stack to be used by cog capturing data.
+    ' UNDONE: Later check how much of this stack has actually been used.
+    LONG m_stack[128]
+    
+    ' Id of cog capturing data.
+    LONG m_cogId
+
+
+PUB init
+    m_swclkPin~~
+    m_swdioPin~~
+    m_clockCount~
+    m_cogId~~
+    
+PUB start(swclkPin, swdioPin)
+    IF m_cogId <> -1
+        ' It is an error to call start twice without an intervening stop call.
+        RETURN -1  
+    m_swclkPin := swclkPin
+    m_swdioPin := swdioPin
+    m_clockCount~
+    LONGFILL(@m_buffer, 0, MAX_CAPTURE_LONGS)
+    RESULT := m_cogId := COGNEW(cogCode, @m_stack)
+    ' Wait for a bit to make sure that cog is fully started before continuing.
+    WAITCNT(CLKFREQ / 10 + CNT)
+
+PUB stop
+    IF m_cogId == -1
+        ' Not running on cog so no need to cleanup
+        RETURN
+    COGSTOP(m_cogId)
+    m_cogId~~
+    
+PRI cogCode | clkMask, bit
+    ' Make SWCLK & SWDIO pins act as input.
+    DIRA[m_swclkPin]~
+    DIRA[m_swdioPin]~
+
+    clkMask := |< m_swclkPin
+    REPEAT
+        ' Wait for SWCLK falling edge.
+        WAITPEQ(0, clkMask, 0)
+    
+        ' Wait for SWCLK rising edge.
+        WAITPEQ(clkMask, clkMask, 0)
+        bit := INA[m_swdioPin]
+        
+        ' Store the bit just received if buffer not already full.
+        IF m_clockCount < MAX_CAPTURE_BITS
+            m_buffer[m_clockCount >> 5] |= bit << (m_clockCount & $1F)
+        m_clockCount++
+                
+PUB getCapturedBits(pBuffer)
+    ' Wait a bit for the last bit to be captured.
+    WAITCNT(CLKFREQ / 10 + CNT)
+    LONGMOVE(pBuffer, @m_buffer, MAX_CAPTURE_LONGS)
+    RESULT := m_clockCount
+    

--- a/SWDHost.spin
+++ b/SWDHost.spin
@@ -1,0 +1,481 @@
+{
+    MIT License
+    
+    Copyright (C) 2019  Adam Green (https://github.com/adamgreen)
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+}
+' SWDHost - Module which can talk to debug targets using ARM's
+'           Serial Wire Debug protocol.
+' NOTE: At this point it only has the ability to read Debug Port
+'       registers and has only been tested reading the IDCODE DP
+'       register since this is the only functionality needed for
+'       JTAGulating.
+
+CON
+    ' Number of times to pulse SWCLK with SWDIO pulled high for line reset.
+    LINE_RESET_CLK_PULSES = 50
+    ' ARM document mentions a lower rate of 1kHz.
+    ' https://developer.arm.com/docs/dui0499/latest/arm-dstream-target-interface-connections/signal-descriptions/serial-wire-debug
+    SWD_SLOW_CLOCK_RATE = 1000
+    ' The fastest I have been able to run my SWD code without hanging in WAITCNT.
+    SWD_FASTEST_CLOCK_RATE = 385_000
+    
+    ' SWD DP Register Addresses.
+    DP_IDCODE = $0      ' Read-only
+    DP_ABORT = $0       ' Write-only
+    DP_CTRL_STAT = $4   ' Read/Write w/ CTRLSEL = 0
+    DP_WCR = $4         ' Read/Write w/ CTRLSEL = 1
+    DP_RESEND = $8      ' Read-only
+    DP_SELECT = $8      ' Write-only
+    DP_RDBUFF = $C      ' Read-only
+
+    ' SWD Response Codes.
+    RESP_OK = %001
+    RESP_WAIT = %010
+    RESP_FAULT = %100
+    RESP_PARITY = %1000 ' Special code to indicate we got data parity error.
+    
+    ' Read/Write bit.
+    READ = 1
+    WRITE = 0
+    
+    ' AP/DP bit.    
+    AP = 1
+    DP = 0
+    
+    ' Supported SWD operations.
+    #0, OP_CONFIG, OP_RESET, OP_JTAG2SWD, OP_IDLE, OP_READ
+
+
+VAR
+    ' ID of the cog on which the SWD PASM code is running.
+    LONG m_cogId
+    
+    ' NOTE: Maintain the order of the following variables as they are accessed from
+    '       PASM via PAR pointer.
+    ' Pin configuration.
+    LONG m_swclkPin
+    LONG m_swdioPin
+    ' Number of Propeller clock cycles per half pulse.
+    LONG m_delay
+    ' Each command is given a unique id. It is updated after other command fields are
+    ' set to let SWD cog know that there is a new command to process.
+    LONG m_cmdIndex
+    ' What command should be executed next by the SWD cog. One of the OP_* enumeration.
+    LONG m_cmdOp
+    ' Operand for current command, if any.
+    LONG m_cmdOperand
+    ' The SWD cog sets this id to match the m_cmdIndex of the command that it has just
+    ' finished processing. It updates it after all other response fields are filled in
+    ' to let the main cog know that it is done.
+    LONG m_respIndex
+    ' 3-bit ACK response from target for read/writes.
+    LONG m_respAck
+    ' 32-bit data response from target for reads.
+    LONG m_respData
+
+
+' Initialize the SWD host module.
+'   Starts the SWD code running on its own cog. You need to call config()
+'   to setup the pins and frequency to be used when processing future SWD
+'   calls.
+' Returns
+'   The index of the cog on which the SWD code was started or -1 if there
+'   was no free cog.
+PUB init
+    ' Clear members that will be filled in later at config time.
+    m_swclkPin~~
+    m_swdioPin~~
+    m_delay~
+    ' Zero out the command & response fields.
+    m_cmdIndex~
+    m_respIndex~
+    ' Start up the SWD PASM code on its own cog.
+    RESULT := m_cogId := COGNEW(@SwdRoutine, @m_swclkPin)
+
+' Cleans up the SWD module.
+'   Call this once the SWD module is no longer needed so that the cog
+'   running the SWD code can be freed for other uses.
+PUB uninit
+    IF m_cogId <> -1
+        COGSTOP(m_cogId)
+        m_cogId~~
+    m_swclkPin~~
+    m_swdioPin~~
+
+' Configure the SWD module to use specified pins and frequency.
+'   Call this function after .init to tell the SWD cog which pins
+'   (SWCLK & SWDIO) and frequency it should use for future method
+'   calls. It can be called multiple times, allowing the user to
+'   change which pins and/or frequency are used for SWD communication.
+' Parameters
+'   swclkPin indicates which of the Propeller pins is connected to SWCLK.
+'   swdioPin indicates which of the Propeller pins is connected to SWDIO.
+'   frequency indicates how fast the SWCLK should pulse, in Hertz. It can
+'       be set between SWD_SLOW_CLOCK_RATE and SWD_FASTEST_CLOCK_RATE.
+PUB config(swclkPin, swdioPin, frequency)
+    ' Store away pins to be used for SWD operations.
+    m_swclkPin := swclkPin
+    m_swdioPin := swdioPin
+    ' Calculate CNT cycles to delay for each phase of SWCLK output.
+    m_delay := CLKFREQ / (frequency * 2)
+    ' Make sure that the current cog isn't holding either of these pins high so that
+    ' the SWD cog can't manipulate them properly.
+    DIRA[m_swdioPin]~
+    DIRA[m_swclkPin]~
+    ' Tell the SWD cog to pickup these new pin and frequency setings.
+    m_cmdOp := OP_CONFIG
+    m_cmdIndex++
+    REPEAT UNTIL m_respIndex == m_cmdIndex
+        ' Waiting for SWD cog to complete command.
+
+' Reset SerialWire-Jtag debug access port into SWD mode and read out its IDCODE.
+'   Reading the IDCODE is one of the few things that a SWD target will allow after
+'   a mode switch so this function does both at once.
+' Parameters
+'   pValue is a pointer to a 32-bit value to be filled in with the IDCODE.
+' Returns
+'   The 3-bit RESP_* ack value sent back from the target or RESP_PARITY if the
+'   data portion failed parity checking.
+'   NOTE: If the response isn't RESP_OK then the IDCODE isn't read into pValue. 
+PUB resetSwJtagAndReadIdCode(pValue)
+    sendLineReset
+    sendJtagToSwdSequence
+    sendLineReset
+    idleBus(2)
+    RETURN readDP(DP_IDCODE, pValue)
+
+' Reset the target and read out its IDCODE.
+'   Reading the IDCODE is one of the few things that a SWD target will allow after
+'   a line reset so this function does both at once. It is more common to use the
+'   resetSwJtagAndReadIrCode() method instead of this one since most ARM Cortex-M
+'   processors support JTAG on the same pins used for SWD.
+' Parameters
+'   pValue is a pointer to a 32-bit value to be filled in with the IDCODE.
+' Returns
+'   The 3-bit RESP_* ack value sent back from the target or RESP_PARITY if the
+'   data portion failed parity checking.
+'   NOTE: If the response isn't RESP_OK then the IDCODE isn't read into pValue. 
+PUB resetAndReadIdCode(pValue)
+    sendLineReset
+    idleBus(2)
+    RETURN readDP(DP_IDCODE, pValue)
+
+' Sends line reset to SWD target.
+'   This is done by pulsing SWCLK 50 times with SWDIO held high. This is a lower
+'   level method and higher level methods like resetAndReadIrCode() or 
+'   resetSwJtagAndReadIrCode() should be considered instead.
+PUB sendLineReset | id
+    m_cmdOp := OP_RESET
+    m_cmdIndex++
+    REPEAT UNTIL m_respIndex == m_cmdIndex
+        ' Waiting for SWD cog to complete command.
+
+' Sends special sequence over TMS/SDWDIO which will switch from JTAG mode to
+' SWD mode if the attached device is using the SWJ-DebugPort which supports
+' both methods of communication. This is a lower level method and a higher 
+' level method like resetSwJtagAndReadIrCode() should be considered instead.
+PUB sendJtagToSwdSequence | data
+    m_cmdOp := OP_JTAG2SWD
+    m_cmdIndex++
+    REPEAT UNTIL m_respIndex == m_cmdIndex
+        ' Waiting for SWD cog to complete command.
+
+' Commands the SWD bus to idle for the specified number of clock cycles.
+'   Idling is SWCLK pulses with SWDIO held low.
+' Parameters
+'   count is the number of SWCLK pulses to idle the SWD bus. The maximum allowed
+'         value is 32. Can be called multiple times to workaround this maximum.
+PUB idleBus(count)
+    m_cmdOp := OP_IDLE
+    m_cmdOperand := count <# 32
+    m_cmdIndex++
+    REPEAT UNTIL m_respIndex == m_cmdIndex
+        ' Waiting for SWD cog to complete command.
+
+' Reads the specified Debug Port register.
+' Parameters
+'   address is the 4-bit address of the register to be read.
+'   pValue is a pointer to a 32-bit value to be filled in with the register contents.
+' Returns
+'   The 3-bit RESP_* ack value sent back from the target or RESP_PARITY if the
+'   data portion failed parity checking.
+'   NOTE: If the response isn't RESP_OK then the register contents aren't read 
+'         into pValue. 
+PUB readDP(address, pValue) : response | data
+    m_cmdOp := OP_READ
+    m_cmdOperand := buildPacketRequest(DP, READ, address)
+    m_cmdIndex++
+    REPEAT UNTIL m_respIndex == m_cmdIndex
+        ' Waiting for SWD cog to complete command.
+    IF m_respAck == RESP_OK
+        LONG[pValue] := m_respData  
+    response := m_respAck  
+
+PRI buildPacketRequest(APnDP, RnW, address) : packet
+    ' Only send upper 2-bits of the 4-bit address.
+    address := (address >> 2) & $3
+    ' Build up 8-bit packet request [start(1), APnDP, RnW, 2-bit address, parity, stop(0), park(1)]
+    ' The bits are in reverse order where start is lsb and stop in msb.
+    packet := %10000001 | (APnDP << 1) | (RnW << 2) | (address << 3)
+    ' Parity is over 4-bits, starting at second bit (ignores start and stop bits).
+    packet |= calcParity(packet, 1, 4) << 5
+    
+PRI calcParity(value, skipBits, _bitCount) : parity
+    value >>= skipBits
+    parity~
+    REPEAT WHILE _bitCount--
+        parity ^= (value & 1)
+        value >>= 1
+
+
+DAT
+                ORG 0
+                
+                ' This is the SWD PASM code which does the bulk of the SWD
+                ' communication on its own cog.
+SwdRoutine
+                MOV TempAddr, PAR
+                ' Store away addresses of command and response fields.
+                ' Skip m_swclkPin, m_swdioPin, and m_delay LONGS.
+                ADD TempAddr, #4*3 
+                MOV CmdIndexAddr, TempAddr
+                ADD TempAddr, #4
+                MOV CmdOpAddr, TempAddr
+                ADD TempAddr, #4
+                MOV CmdOperandAddr, TempAddr
+                ADD TempAddr, #4
+                MOV RespIndexAddr, TempAddr
+                ADD TempAddr, #4
+                MOV RespAckAddr, TempAddr
+                ADD TempAddr, #4
+                MOV RespDataAddr, TempAddr
+                ' Initialize command index.
+                RDLONG LastIndex, RespIndexAddr
+                ' Initialize timer variables.
+                ' UNDONE: Only need to do this here if we want to idle while waiting 
+                '         for new commands.
+                MOV Time, CNT
+                ADD Time, Delay
+
+:NextCmd        ' Setup for next command.
+                ' UNDONE: Would prefer to force SWDIO low if that will work on nRF51822 since that is idle.
+                ' MOV TempVal, INA
+:WaitCmd        ' Wait for next command.
+{
+                ' Toggle clock pin while waiting.
+                '   Falling edge.
+                WAITCNT Time, Delay
+                ANDN TempVal, SwclkPinMask
+                MOV OUTA, TempVal
+                '   Rising edge.
+                WAITCNT Time, Delay
+                OR TempVal, SwclkPinMask
+                MOV OUTA, TempVal
+}
+                ' UNDONE: Might want to move this up to after the first WAITCNT so that
+                '         batched commands don't have idle introduced unless really needed.
+                ' See if the command index has been incremented to indicate a new command.
+                RDLONG CurrIndex, CmdIndexAddr
+                CMP CurrIndex, LastIndex WZ
+                IF_E JMP #:WaitCmd
+                
+                ' UNDONE: Don't need to do this here if idling while waiting for next command.
+                ' Initialize timer variable again since we aren't idling above.
+                MOV Time, CNT
+                ADD Time, Delay
+                
+                ' Jump to the handler for the requested command.
+                RDLONG TempVal, CmdOpAddr
+                CMP TempVal, #OP_CONFIG WZ
+                IF_E JMP #:ConfigPinsFreq
+                CMP TempVal, #OP_JTAG2SWD WZ
+                IF_E JMP #:JTAG2SWD
+                CMP TempVal, #OP_IDLE WZ
+                IF_E JMP #:IdleBus
+                CMP TempVal, #OP_READ WZ
+                IF_E JMP #:ReadRegister
+                ' Get here if the command was OP_RESET.
+                
+:ResetCmd       ' Clock out 50 SWCLK pulses with SWDIO held high.
+                '  Do 32 bits first...
+                ABSNEG DataOut, #1
+                MOV BitCount, #32
+                CALL #ClockInOut
+                '  Do the remaining 18-bits.
+                ABSNEG DataOut, #1
+                MOV BitCount, #18
+                CALL #ClockInOut
+                JMP #:CmdDone
+
+:ConfigPinsFreq ' Configure this code to use caller specified pins and frequency.
+                MOV TempAddr, PAR
+                ' SWCLK Pin mask from m_swclkPin.
+                RDLONG TempVal, TempAddr
+                MOV SwclkPinMask, #1
+                SHL SwclkPinMask, TempVal
+                ' SWDIO Pin mask from m_sdwioPin.
+                ADD TempAddr, #4
+                RDLONG TempVal, TempAddr
+                MOV SwdioPinMask, #1
+                SHL SwdioPinMask, TempVal
+                ' Fetch delay from main memory.
+                ADD TempAddr, #4
+                RDLONG Delay, TempAddr
+                ' Configure SWCLK and SWDIO pins as output.
+                MOV TempVal, SwdioPinMask
+                OR TempVal, SwclkPinMask
+                MOV DIRA, TempVal
+                ' Start out with SWCLK and SWDIO pins both set low.
+                MOV OUTA, #0
+                JMP #:CmdDone
+                
+:JTAG2SWD       ' Send the $E79E JTAG to SWD bit sequence out over TMS/SWDIO.
+                MOV DataOut, Jtag2SwdSeq
+                MOV BitCount, #16
+                CALL #ClockInOut
+                JMP #:CmdDone
+
+:IdleBus        ' Clock out specified number of SWCLK pulses with SWDIO held low.
+                RDLONG BitCount, CmdOperandAddr
+                MOV DataOut, #0
+                CALL #ClockInOut
+                JMP #:CmdDone
+
+:ReadRegister   ' Read a DP or AP register.
+                ' Packet request is already filled out in m_cmdOperand by Spin code.
+                RDLONG DataOut, CmdOperandAddr
+                MOV BitCount, #8
+                CALL #ClockInOut
+                ' Switch SWDIO to input and issue turn-around cycle.
+                '   SWCLK falling edge.
+                WAITCNT Time, Delay
+                MOV DIRA, SwclkPinMask ' Only setting SWCLK pin as output.
+                MOV OUTA, #0
+                '   SWCLK rising edge.
+                WAITCNT Time, Delay
+                MOV OUTA, SwclkPinMask
+                ' Read in the 3-bit ACK response.
+                MOV BitCount, #3
+                CALL #ClockInOut
+                WRLONG DataIn, RespAckAddr
+                ' Nothing more to do if ACK response wasn't RESP_OK.
+                CMP DataIn, #RESP_OK WZ
+                IF_NE JMP #:TurnAroundDone
+                ' Read in the 32-bit register value.
+                MOV DataInParity, #0
+                MOV BitCount, #32
+                CALL #ClockInOut
+                WRLONG DataIn, RespDataAddr
+                ' Read in the parity bit.
+                MOV BitCount, #1
+                CALL #ClockInOut
+                ' Final parity should be even.
+                TEST DataInParity, HighBit WZ
+                IF_E JMP #:TurnAroundDone
+                ' Parity wasn't even so flag parity error.
+                MOV TempVal, #RESP_PARITY
+                WRLONG TempVal, RespAckAddr
+                ' Fall through to :TurnAroundDone
+
+:TurnAroundDone ' Issue final turn around cycle and make SWDIO output again.
+                ' UNDONE: Should really switch to output on next clock cycle.
+                '   SWCLK falling edge.
+                WAITCNT Time, Delay
+                MOV OUTA, #0
+                '   SWCLK rising edge.
+                WAITCNT Time, Delay
+                MOV TempVal, SwclkPinMask
+                OR TempVal, SwdioPinMask
+                MOV DIRA, TempVal
+                MOV OUTA, SwclkPinMask
+                ' Fall through to :CmdDone
+                 
+:CmdDone        ' Update m_respIndex to let calling cog know we are done with 
+                ' the current command.             
+                MOV LastIndex, CurrIndex
+                WRLONG LastIndex, RespIndexAddr
+                ' Jump back to wait for next command.
+                JMP #:NextCmd
+
+
+' Routine to clock data out/in over SWDIO.
+' Call with:
+'   BitCount = number of bits to shift in/out (maximum of 32).
+'   DataOut = bits to be shifted out least significant bit first.
+' Returns:
+'   DataIn = bits shifted in, least significant bit is first bit received.
+'   DataInParity = the parity of DataIn bits are accumulated in MSB of this
+'                  variable. It must be manually cleared by caller.
+ClockInOut      MOV LoopCount, BitCount
+                MOV TempVal, INA
+                MOV DataIn, #0
+:Loop           ' Set SWDIO output to lsb of DataOut before next SWCLK falling edge.
+                WAITCNT Time, Delay
+                TEST DataOut, #1 WZ
+                MUXNZ TempVal, SwdioPinMask
+                SHR DataOut, #1
+                ' SWCLK falling edge.
+                ANDN TempVal, SwclkPinMask
+                MOV OUTA, TempVal
+                ' Shift in the next bit from SWDIO into DataIn before SWCLK rising edge.
+                WAITCNT Time, Delay
+                SHR DataIn, #1
+                TEST SwdioPinMask, INA WZ
+                MUXNZ DataIn, HighBit
+                XOR DataInParity, DataIn
+                ' SWCLK rising edge.
+                OR TempVal, SwclkPinMask
+                MOV OUTA, TempVal
+                ' Loop around until all desired bits have been clocked in/out.
+                DJNZ LoopCount, #:Loop
+                ' Right justify the bits in DataIn.
+                MOV TempVal, #32
+                SUB TempVal, BitCount
+                SHR DataIn, TempVal
+                ' Return to caller.
+ClockInOut_ret  RET
+
+
+HighBit         LONG 1 << 31
+Jtag2SwdSeq     LONG $E79E
+
+TempAddr        RES 1
+TempVal         RES 1
+SwclkPinMask    RES 1
+SwdioPinMask    RES 1
+Delay           RES 1
+Time            RES 1
+LoopCount       RES 1
+CmdIndexAddr    RES 1
+CmdOpAddr       RES 1
+CmdOperandAddr  RES 1
+RespIndexAddr   RES 1
+RespAckAddr     RES 1
+RespDataAddr    RES 1
+LastIndex       RES 1
+CurrIndex       RES 1
+BitCount        RES 1
+DataOut         RES 1
+DataIn          RES 1
+DataInParity    RES 1
+SavedParity     RES 1
+                
+                FIT

--- a/SWDTarget.spin
+++ b/SWDTarget.spin
@@ -1,0 +1,240 @@
+{
+    MIT License
+    
+    Copyright (C) 2019  Adam Green (https://github.com/adamgreen)
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+}
+' SWDTarget - Module which emulates a debug target which speaks ARM's
+'             Serial Wire Debug protocol.
+'             Currently just used to unit test the SWDHost module.
+' NOTE: At this point it only has the ability to simulate reading of
+'       the IDCODE Debug Port register since this is the only 
+'       functionality needed for JTAGulating.
+
+CON
+    ' SWD DP Register Addresses.
+    DP_IDCODE = $0      ' Read-only
+    DP_ABORT = $0       ' Write-only
+    DP_CTRL_STAT = $4   ' Read/Write w/ CTRLSEL = 0
+    DP_WCR = $4         ' Read/Write w/ CTRLSEL = 1
+    DP_RESEND = $8      ' Read-only
+    DP_SELECT = $8      ' Write-only
+    DP_RDBUFF = $C      ' Read-only
+
+    ' SWD Response Codes.
+    RESP_OK = %001
+    RESP_WAIT = %010
+    RESP_FAULT = %100
+
+    ' States of data transfer.
+    #0, STATE_REQUEST, STATE_ACK, STATE_DATA, STATE_TURNAROUND
+    
+VAR
+    ' Pin configuration.
+    BYTE m_swclkPin
+    BYTE m_swdioPin
+    
+    ' IDCODE response value.
+    LONG m_idcode
+    
+    ' Whether a parity error should be introduced.
+    LONG m_introduceParityError
+    
+    ' Error, if any, to return as ACK response.
+    LONG m_response
+    
+    ' Number of rising edges detected on SWCLK pin.
+    LONG m_clockCount
+    
+    ' Number of consecutive rising edges with SWDIO held high.
+    ' Used to detect line reset.
+    LONG m_highCount
+    
+    ' Minimum time between rising edges.
+    long m_minTime
+    
+    ' Stack to be used by cog acting as SWD target.
+    ' UNDONE: Later check how much of this stack has actually been used.
+    LONG m_stack[128]
+    
+    ' Id of cog acting as SWD target.
+    LONG m_cogId
+
+
+PUB init
+    m_swclkPin~~
+    m_swdioPin~~
+    m_clockCount~
+    m_highCount~
+    m_idcode~
+    m_introduceParityError~
+    m_response := RESP_OK
+    m_minTime := POSX
+    m_cogId~~
+    
+PUB start(swclkPin, swdioPin)
+    IF m_cogId <> -1
+        ' It is an error to call start twice without an intervening stop call.
+        RETURN -1  
+    m_swclkPin := swclkPin
+    m_swdioPin := swdioPin
+    m_clockCount~
+    m_highCount~
+    m_idcode~
+    m_introduceParityError~
+    m_response := RESP_OK
+    m_minTime := POSX
+    RESULT := m_cogId := COGNEW(cogCode, @m_stack)
+    ' Wait for a bit to make sure that cog is fully started before continuing.
+    WAITCNT(CLKFREQ / 10 + CNT)
+
+PUB stop
+    IF m_cogId == -1
+        ' Not running on cog so no need to cleanup
+        RETURN
+    COGSTOP(m_cogId)
+    m_cogId~~
+    
+PRI cogCode | clkMask, bit, state, request, tst, isRead, ack, payload, count, parity, switch2Input, skipData, lastCnt, currCnt
+    ' Make SWDCLK pin act as input
+    DIRA[m_swclkPin]~
+
+    lastCnt := CNT - CLKFREQ
+    clkMask := |< m_swclkPin
+    state := STATE_REQUEST
+    request~
+    switch2Input~~
+    REPEAT
+        ' Wait for SWCLK falling edge.
+        WAITPEQ(0, clkMask, 0)
+        currCnt := CNT
+        m_minTime <#= (currCnt - lastCnt)
+        lastCnt := currCnt
+        IF switch2Input
+            DIRA[m_swdioPin]~
+            switch2Input~
+    
+        ' Wait for SWCLK rising edge.
+        WAITPEQ(clkMask, clkMask, 0)
+        bit := INA[m_swdioPin]
+        m_clockCount++
+        
+        ' Check for a line reset (50 consecutive rising clock edges with 
+        ' SWDIO set high.)
+        IF bit
+            m_highCount :=  m_highCount + 1 <# 50
+            IF m_highCount == 50
+                state := STATE_REQUEST
+                request~
+                NEXT
+        ELSE
+            m_highCount~
+
+        CASE state
+            STATE_REQUEST:
+                ' Shift in this bit.
+                request >>= 1
+                request |= bit << 31
+                
+                ' See if we have a valid packet request yet.
+                ' Start bit (bit 0) == 1
+                ' Stop bit (bit 6) == 0
+                ' Valid parity of bits 1-5
+                tst := request >> CONSTANT(32-8)
+                IF (tst & 1) AND NOT(tst & CONSTANT(|<6)) AND NOT calcParity(tst, 1, 5)
+                    processRequest(tst, @isRead, @ack, @payload)
+                    ' Prepare to start sending back the 3-bit ack.
+                    state := STATE_ACK
+                    count := 3
+                    skipData := ack <> RESP_OK
+            STATE_ACK:
+                ' Shift out the next ack bit.
+                DIRA[m_swdioPin]~~
+                OUTA[m_swdioPin] := ack & 1
+                ack >>= 1
+                IF NOT --count
+                    IF skipData
+                        state := STATE_REQUEST
+                        request~
+                        switch2Input~~
+                    ELSE
+                        state := STATE_DATA
+                        count := 32
+                        parity~
+            STATE_DATA:
+                ' UNDONE: Only supports read at this point.
+                ' UNDONE: Don't need to do this state if FAULT or WAIT is returned and not using overrun detection.
+                IF count
+                    ' Shift out the next payload bit.
+                    bit := payload & 1
+                    parity ^= bit
+                    OUTA[m_swdioPin] := bit
+                    payload >>= 1
+                    count--
+                ELSE
+                    ' Finish off with the parity bit.
+                    OUTA[m_swdioPin] := parity ^ m_introduceParityError
+                    state := STATE_TURNAROUND
+                    switch2Input := TRUE
+            STATE_TURNAROUND:
+                state := STATE_REQUEST
+                request~
+
+PRI calcParity(value, skipBits, bitCount) : parity
+    value >>= skipBits
+    parity~
+    REPEAT WHILE bitCount--
+        parity ^= (value & 1)
+        value >>= 1
+        
+PRI processRequest(tst, pIsRead, pAck, pPayload) | isRead, isApRequest, address
+    isRead := tst & CONSTANT(|<2)
+    isApRequest := tst & CONSTANT(|<1)
+    address := ((tst >> 3) & 3) << 2
+    IF isRead AND NOT isApRequest AND address == DP_IDCODE
+        LONG[pAck] := RESP_OK
+        LONG[pPayload] := m_idcode
+    ELSE
+        LONG[pAck] := RESP_FAULT
+        LONG[pPayload] := 0
+    LONG[pIsRead] := isRead
+    IF m_response <> RESP_OK
+        LONG[pAck] := m_response
+
+PUB clockCounts
+    RETURN m_clockCount
+    
+PUB inLineResetState : wasReset | count
+    RETURN m_highCount == 50
+
+PUB setIDCODE(idcode)
+    m_idcode := idcode
+
+PUB introduceParityError(enable)
+    IF enable
+        m_introduceParityError := 1
+    ELSE
+        m_introduceParityError~ 
+        
+PUB introduceResponseError(response)
+    m_response := response
+
+PUB frequency
+    RETURN CLKFREQ / m_minTime

--- a/TestSWD.spin
+++ b/TestSWD.spin
@@ -1,0 +1,391 @@
+{
+    MIT License
+    
+    Copyright (C) 2019  Adam Green (https://github.com/adamgreen)
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+}
+' Unit tests for the SWD (ARM's Serial Wire Debug) modules.
+' The SWDHost module is used by the JTAGulator to probe for potential
+' SWD devices connected to its pins.
+' The SWDTarget module is currently only used to unit test the SWDHost
+' module and doesn't get compiled into the actual JTAGulator code.
+
+CON
+    ' System Clock Frequency set to 80MHz.
+    _CLKFREQ = 80_000_000
+    _CLKMODE = XTAL1 | PLL16X
+
+OBJ
+    tst: "UnitTest"
+    host: "SWDHost"
+    target: "SWDTarget"
+    capture: "SWDCapture"
+    
+VAR
+    LONG m_buffer[capture#MAX_CAPTURE_LONGS]
+        
+PUB Main | status, value, bitCount
+    tst.init
+    target.init
+    capture.init
+    host.init
+    
+    ' --------------------------------------------------------------------------------
+    ' Testing of SWDTarget module's detection of line reset (50 SWCLKs of SWDIO 
+    ' held high.)
+    ' --------------------------------------------------------------------------------
+    tst.start(STRING("No line reset"))
+        target.start(0, 1)
+        tst.checkLong(@clockCountsMsg, target.clockCounts, 0)
+        tst.checkLong(@lineResetMsg, target.inLineResetState, FALSE)
+        target.stop
+    tst.end
+
+    tst.start(STRING("Bad line reset - 1 too few clocks"))
+        target.start(0, 1)
+        ' Perform a line reset incorrectly, with 1 too few clock cycles (49 instead of 50).
+        OUTA[0..1]~
+        DIRA[0..1]~~
+        cyclePin(0, 49)
+        ' Should fail to register a line detect.
+        tst.checkLong(@clockCountsMsg, target.clockCounts, 49)
+        tst.checkLong(@lineResetMsg, target.inLineResetState, FALSE)
+        target.stop
+    tst.end
+
+    tst.start(STRING("Bad line reset - 1 too few high SWDIO"))
+        target.start(0, 1)
+        ' Perform 49 clocks with SWDIO high.
+        OUTA[0..1]~
+        DIRA[0..1]~~
+        cyclePin(0, 49)
+        ' Incorrectly set SWDIO low for this last clock cycle.
+        OUTA[1]~
+        cyclePin(0, 1)
+        ' Should fail to register a line detect.
+        tst.checkLong(@clockCountsMsg, target.clockCounts, 50)
+        tst.checkLong(@lineResetMsg, target.inLineResetState, FALSE)
+        target.stop
+    tst.end
+
+    tst.start(STRING("Line reset - 1 low SWDIO in middle"))
+        target.start(0, 1)
+        ' Perform 49 clocks with SWDIO high.
+        OUTA[0..1]~
+        DIRA[0..1]~~
+        cyclePin(0, 49)
+        ' Set SWDIO low for this middle clock cycle.
+        OUTA[1]~
+        cyclePin(0, 1)
+        ' Do almost a full 50 clocks with SWDIO high to complete a good line reset.
+        OUTA[1]~~
+        cyclePin(0, 49)
+        ' Should still not be in line reset state until another clock edge is seen.
+        tst.checkLong(@lineResetMsg, target.inLineResetState, FALSE)
+        cyclePin(0, 1)
+        ' Second set should register a line detect.
+        tst.checkLong(@clockCountsMsg, target.clockCounts, 100)
+        tst.checkLong(@lineResetMsg, target.inLineResetState, TRUE)
+        target.stop
+    tst.end
+
+
+    ' --------------------------------------------------------------------------------
+    ' Tests of host.sendLineReset.
+    ' --------------------------------------------------------------------------------
+    tst.start(STRING("Capture line reset"))
+        capture.start(0, 1)
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        host.sendLineReset
+        bitCount := capture.getCapturedBits(@m_buffer)
+        tst.checkLong(@bitCountMsg, bitCount, 50)
+        tst.checkLong(@buffer0Msg, m_buffer[0], $FFFFFFFF) ' First 32 clocks of SWDIO high.
+        tst.checkLong(@buffer1Msg, m_buffer[1], %111111111111111111) ' Last 18 clocks.
+        tst.checkLong(@buffer2Msg, m_buffer[2], 0)
+        tst.checkLong(@buffer3Msg, m_buffer[3], 0)
+        capture.stop
+    tst.end
+
+    tst.start(STRING("Line reset"))
+        target.start(0, 1)
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        host.sendLineReset
+        tst.checkLong(@clockCountsMsg, target.clockCounts, 50)
+        tst.checkLong(@lineResetMsg, target.inLineResetState, TRUE)
+        target.stop
+    tst.end
+
+    tst.start(STRING("Line reset on different pins"))
+        target.start(15, 14)
+        host.config(15, 14, host#SWD_SLOW_CLOCK_RATE)
+        host.sendLineReset
+        tst.checkLong(@clockCountsMsg, target.clockCounts, 50)
+        tst.checkLong(@lineResetMsg, target.inLineResetState, TRUE)
+        target.stop
+    tst.end
+
+    tst.start(STRING("inLineResetState clears on first low SWDIO detected"))
+        target.start(0, 1)
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        host.sendLineReset
+        tst.checkLong(@clockCountsMsg, target.clockCounts, 50)
+        tst.checkLong(@lineResetMsg, target.inLineResetState, TRUE)
+        ' Should leave reset as soon as SWDIO is set low (idled) for a clock pulse.
+        host.idleBus(1)
+        tst.checkLong(@clockCountsMsg, target.clockCounts, 51)
+        tst.checkLong(@lineResetMsg, target.inLineResetState, FALSE)
+        target.stop
+    tst.end
+
+
+    ' --------------------------------------------------------------------------------
+    ' Tests of host.sendJtagToSwdSequence.
+    ' --------------------------------------------------------------------------------
+    tst.start(STRING("Capture sendJtagToSwdSequence"))
+        capture.start(0, 1)
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        host.sendJtagToSwdSequence
+        bitCount := capture.getCapturedBits(@m_buffer)
+        tst.checkLong(@bitCountMsg, bitCount, 16)
+        ' 16-bits of switch command.
+        tst.checkLong(@buffer0Msg, m_buffer[0], %1110_0111_1001_1110) 
+        tst.checkLong(@buffer1Msg, m_buffer[1], 0) 
+        tst.checkLong(@buffer2Msg, m_buffer[2], 0) 
+        tst.checkLong(@buffer3Msg, m_buffer[3], 0) 
+        capture.stop
+    tst.end
+
+
+    ' --------------------------------------------------------------------------------
+    ' Tests of host.idleBus
+    ' --------------------------------------------------------------------------------
+    tst.start(STRING("Capture idleBus(2)"))
+        capture.start(0, 1)
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        host.idleBus(2)
+        bitCount := capture.getCapturedBits(@m_buffer)
+        tst.checkLong(@bitCountMsg, bitCount, 2)
+        ' 2 bits of SWDIO = 0
+        tst.checkLong(@buffer0Msg, m_buffer[0], %00) 
+        tst.checkLong(@buffer1Msg, m_buffer[1], 0) 
+        tst.checkLong(@buffer2Msg, m_buffer[2], 0) 
+        tst.checkLong(@buffer3Msg, m_buffer[3], 0) 
+        capture.stop
+    tst.end
+
+    tst.start(STRING("Capture idleBus(32)"))
+        capture.start(0, 1)
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        host.idleBus(32)
+        bitCount := capture.getCapturedBits(@m_buffer)
+        tst.checkLong(@bitCountMsg, bitCount, 32)
+        ' 32 bits of SWDIO = 0.
+        tst.checkLong(@buffer0Msg, m_buffer[0], 0) 
+        tst.checkLong(@buffer1Msg, m_buffer[1], 0) 
+        tst.checkLong(@buffer2Msg, m_buffer[2], 0) 
+        tst.checkLong(@buffer3Msg, m_buffer[3], 0) 
+        capture.stop
+    tst.end
+
+    tst.start(STRING("Capture idleBus(33) limited to 32"))
+        capture.start(0, 1)
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        host.idleBus(32)
+        bitCount := capture.getCapturedBits(@m_buffer)
+        tst.checkLong(@bitCountMsg, bitCount, 32)
+        ' 32 bits of SWDIO = 0.
+        tst.checkLong(@buffer0Msg, m_buffer[0], 0) 
+        tst.checkLong(@buffer1Msg, m_buffer[1], 0) 
+        tst.checkLong(@buffer2Msg, m_buffer[2], 0) 
+        tst.checkLong(@buffer3Msg, m_buffer[3], 0) 
+        capture.stop
+    tst.end
+
+    ' --------------------------------------------------------------------------------
+    ' Tests of host.readDP()
+    ' --------------------------------------------------------------------------------
+    tst.start(STRING("readDP(host#DP_IDCODE, ...) #1 @ 1kHz"))
+        target.start(0, 1)
+        target.setIDCODE($12345678)
+        host.config(0, 1, 1000)
+        status := host.readDP(host#DP_IDCODE, @value)
+        tst.checkLong(@statusMsg, status, host#RESP_OK)
+        tst.checkLong(@valueMsg, value, $12345678)
+        tst.checkLong(@freqMsg, target.frequency, 1000)
+        target.stop
+    tst.end
+
+    tst.start(STRING("readDP(host#DP_IDCODE, ...) #2 @ 1024Hz"))
+        target.start(0, 1)
+        target.setIDCODE($87654321)
+        host.config(0, 1, 1024)
+        status := host.readDP(host#DP_IDCODE, @value)
+        tst.checkLong(@statusMsg, status, host#RESP_OK)
+        tst.checkLong(@valueMsg, value, $87654321)
+        tst.checkLong(@freqMsg, target.frequency, 1024)
+        target.stop
+    tst.end
+
+    tst.start(STRING("Capture readDP(host#DP_IDCODE, ...)"))
+        target.start(0, 1)
+        target.setIDCODE($12345678)
+        capture.start(0, 1)
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        host.readDP(host#DP_IDCODE, @value)
+        bitCount := capture.getCapturedBits(@m_buffer)
+        ' 8-bit packet request + 1-bit turn-around + 3-bit ack + 32-bit data +
+        ' 1-bit parity + 1-bit turn-around.
+        tst.checkLong(@bitCountMsg, bitCount, 8+1+3+32+1+1)
+        '                                         $4   $5   $6   $7   $8  ack t  packet
+        tst.checkLong(@buffer0Msg, m_buffer[0], %0100_0101_0110_0111_1000_001_1_10100101) 
+        '                                        t p  $1   $2   $3
+        tst.checkLong(@buffer1Msg, m_buffer[1], %0_1_0001_0010_0011) 
+        tst.checkLong(@buffer2Msg, m_buffer[2], 0) 
+        tst.checkLong(@buffer3Msg, m_buffer[3], 0) 
+        capture.stop
+        target.stop
+    tst.end
+
+    tst.start(STRING("Call readDP() twice"))
+        target.start(0, 1)
+        target.setIDCODE($12345678)
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        status := host.readDP(host#DP_IDCODE, @value)
+        tst.checkLong(@statusMsg, status, host#RESP_OK)
+        tst.checkLong(@valueMsg, value, $12345678)
+        target.setIDCODE($87654321)
+        status := host.readDP(host#DP_IDCODE, @value)
+        tst.checkLong(@statusMsg, status, host#RESP_OK)
+        tst.checkLong(@valueMsg, value, $87654321)
+        target.stop
+    tst.end
+
+    tst.start(STRING("readDP w/ parity error"))
+        target.start(0, 1)
+        target.setIDCODE($12345678)
+        target.introduceParityError(TRUE)
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        status := host.readDP(host#DP_IDCODE, @value)
+        tst.checkLong(@statusMsg, status, host#RESP_PARITY)
+        target.stop
+    tst.end
+
+    tst.start(STRING("readDP w/ failure response"))
+        target.start(0, 1)
+        target.setIDCODE($12345678)
+        target.introduceResponseError(host#RESP_FAULT)
+        value := $baadf00d
+        host.config(0, 1, host#SWD_SLOW_CLOCK_RATE)
+        status := host.readDP(host#DP_IDCODE, @value)
+        tst.checkLong(@statusMsg, status, host#RESP_FAULT)
+        ' No data should be read on failure.
+        tst.checkLong(@valueMsg, value, $baadf00d)
+        target.stop
+    tst.end
+
+
+    ' --------------------------------------------------------------------------------
+    ' Tests of resetSwJtagAndReadIdCode() & resetAndReadIdCode()
+    ' --------------------------------------------------------------------------------
+    tst.start(STRING("resetSwJtagAndReadIdCode"))
+        target.start(0, 1)
+        target.setIDCODE($12345678)
+        capture.start(0, 1)
+        host.config(0, 1, 1000)
+        status := host.resetSwJtagAndReadIdCode(@value)
+        tst.checkLong(@statusMsg, status, host#RESP_OK)
+        tst.checkLong(@valueMsg, value, $12345678)
+        bitCount := capture.getCapturedBits(@m_buffer)
+        ' 50-bit reset + 16-bit switch + 50-bit reset + 2-bit idle + 8-bit packet request +
+        ' 1-bit turn-around + 3-bit ack + 32-bit data + 1-bit parity + 1-bit turn-around.
+        tst.checkLong(@bitCountMsg, bitCount, 50+16+50+2+8+1+3+32+1+1)
+        ' First 32-bits of reset.                 reset
+        tst.checkLong(@buffer0Msg, m_buffer[0], $FFFFFFFF) 
+        ' Last 18-bits of reset, first 14-bits of switch command.
+        '                                           switch              reset
+        tst.checkLong(@buffer1Msg, m_buffer[1], %10_0111_1001_1110_111111111111111111) 
+        ' Last 2-bits of switch command and first 30-bits of second reset.
+        '                                                 reset                 switch
+        tst.checkLong(@buffer2Msg, m_buffer[2], %111111111111111111111111111111_11)
+        ' Last 20-bits of reset command, 2-bits of idle, packet, t, first 2-bits of ack.
+        '                                       ack t  packet  i         reset
+        tst.checkLong(@buffer2Msg, m_buffer[3], %01_1_10100101_00_11111111111111111111) 
+        capture.stop
+        target.stop
+    tst.end
+
+    tst.start(STRING("resetAndReadIdCode"))
+        target.start(0, 1)
+        target.setIDCODE($12345678)
+        capture.start(0, 1)
+        host.config(0, 1, 1000)
+        status := host.resetAndReadIdCode(@value)
+        tst.checkLong(@statusMsg, status, host#RESP_OK)
+        tst.checkLong(@valueMsg, value, $12345678)
+        bitCount := capture.getCapturedBits(@m_buffer)
+        ' 50-bit reset + 2-bit idle + 8-bit packet request + 1-bit turn-around + 
+        ' 3-bit ack + 32-bit data + 1-bit parity + 1-bit turn-around.
+        tst.checkLong(@bitCountMsg, bitCount, 50+2+8+1+3+32+1+1)
+        ' First 32-bits of reset.                 reset
+        tst.checkLong(@buffer0Msg, m_buffer[0], $FFFFFFFF) 
+        ' Last 18-bits of reset, 2-bits of idle, packet, t, ack
+        '                                        ack t  packet  i      reset
+        tst.checkLong(@buffer1Msg, m_buffer[1], %001_1_10100101_00_111111111111111111) 
+        ' 32-bit of data.                          data
+        tst.checkLong(@buffer2Msg, m_buffer[2], $12345678) 
+        '                                        t p
+        tst.checkLong(@buffer3Msg, m_buffer[3], %0_1) 
+        capture.stop
+        target.stop
+    tst.end
+    
+    tst.start(STRING("resetSwJtagAndReadIdCode @ highest rate w/o hanging"))
+        value := $baadf00d
+        host.config(0, 1, host#SWD_FASTEST_CLOCK_RATE)
+        status := host.resetSwJtagAndReadIdCode(@value)
+        ' Will fail to actually read since nothing is responding.
+        tst.checkLong(@statusMsg, status, %111)
+        tst.checkLong(@valueMsg, value, $baadf00d)
+    tst.end
+
+    host.uninit
+    tst.stats
+
+PRI cyclePin(pin, count)
+    REPEAT count
+        ' SWCLK Low
+        OUTA[pin]~
+        WAITCNT(CONSTANT(_CLKFREQ/2000) + CNT)
+        ' SWCLK High
+        OUTA[pin]~~
+        WAITCNT(CONSTANT(_CLKFREQ/2000) + CNT)
+
+DAT
+    clockCountsMsg BYTE "target.clockCounts", 0
+    lineResetMsg BYTE "target.inLineResetState", 0
+    statusMsg BYTE "status", 0
+    valueMsg BYTE "value", 0
+    freqMsg BYTE "frequency", 0
+    bitCountMsg BYTE "bitCount", 0
+    buffer0Msg BYTE "m_buffer[0]", 0
+    buffer1Msg BYTE "m_buffer[1]", 0
+    buffer2Msg BYTE "m_buffer[2]", 0
+    buffer3Msg BYTE "m_buffer[3]", 0
+    

--- a/UnitTest.spin
+++ b/UnitTest.spin
@@ -1,0 +1,108 @@
+{
+    MIT License
+    
+    Copyright (C) 2019  Adam Green (https://github.com/adamgreen)
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+}
+' Unit test framework for Propeller based testing. Kind of limited
+' with what I can do here as there is no preprocessor.
+
+OBJ
+    pst: "Parallax Serial Terminal"
+
+VAR
+    ' Pointer to the name of the test currently running.
+    LONG m_pTestName     
+    
+    LONG m_passCount
+    LONG m_failCount
+    LONG m_ignoreCount
+    LONG m_checksFailed
+    LONG m_checkCount   
+    
+PUB init
+    ' Default to using pins 30 (tx) and 31 (rx) at 115200 baud for UART settings.
+    initRxTx(31, 30, 0, 115200)
+    m_passCount~
+    m_failCount~
+    m_ignoreCount~
+    m_pTestName~
+
+PUB initRxTx(rxPin, txPin, mode, baudRate)
+    pst.StartRxTx(rxPin, txPin, mode, baudRate)
+    pst.Clear
+
+PUB start(pTestName)
+    m_pTestName := pTestName
+    m_checksFailed~
+    m_checkCount~
+
+PUB checkLong(pMessage, actual, expected)
+    RESULT := actual == expected
+    IF NOT RESULT
+        pst.NewLine
+        pst.Str(STRING("FAIL: "))
+        pst.Str(m_pTestName)
+        pst.NewLine
+        pst.Str(STRING("      "))
+        pst.Str(pMessage)
+        pst.NewLine
+        pst.Str(STRING("        actual: "))
+        printDecAndHex(actual)
+        pst.NewLine
+        pst.Str(STRING("      expected: "))
+        printDecAndHex(expected)
+        pst.NewLine
+        m_checksFailed++
+    m_checkCount++
+
+PRI printDecAndHex(value)
+    pst.Dec(value)
+    pst.Str(STRING("($"))
+    pst.Hex(value, 8)
+    pst.Char(")")
+    
+PUB end
+    IF m_checksFailed > 0
+        pst.Char("x")
+        m_failCount++
+    ELSEIF m_checkCount == 0
+        pst.Char("!")
+        m_ignoreCount++
+    ELSE
+        pst.Char(".")
+        m_passCount++
+
+PUB stats
+    pst.NewLine
+    pst.NewLine
+    pst.Str(STRING(" Tests passed: "))
+    pst.Dec(m_passCount)
+    pst.NewLine
+    pst.Str(STRING(" Tests failed: "))
+    pst.Dec(m_failCount)
+    pst.NewLine
+    pst.Str(STRING("Tests ignored: "))
+    pst.Dec(m_ignoreCount)
+    pst.NewLine
+    pst.Str(STRING("  Total tests: "))
+    pst.Dec(m_passCount + m_failCount + m_ignoreCount)
+    pst.NewLine
+        


### PR DESCRIPTION
This initial support includes the ability to perform an IDCODE scan via
ARM's Serial Wire Debug protocol.

Tested on:
* NXP LPC43xx Cortex-M4F/M0 board with JTAG and SWD debug support.
* NXP LPC1769 Cortex-M3 board with JTAG and SWD debug support.
* Nordic nRF51822 Cortex-M0 with SWD debug support only.
  * This did fail on an actual product with nRF51822 due to
    an incompatability between the 1k series resistor on JTAGulator
    external data lines and the strong pull-down that the product had
    on the SWCLK line. This halved the voltage of the clock signal.
  * It worked on a PCB of my own design with a chip from the same
    family.

Notes:
* I used the MIT License with my new source files since that is
  consistent with other external Spin modules (PropSerial for example).
  I didn't use the Creative Commons License used by the core JTAGulator
  Spin modules as using Creative Commons for software isn't really 
  recommended by the Creative Commons organization:
  https://creativecommons.org/faq/#can-i-apply-a-creative-commons-license-to-software
  I see Creative Commons licenses used for other parts of Open Source
  Hardware projects such as schematics, PCB layout, etc but not the
  source code.
* This commit includes SWDCapture, SWDTarget, UnitTest, and TestSWD
  SPIN source files which are only used for unit testing the new
  SWDHost module. They aren't compiled into JTAGulator itself so they
  have no impact on its code size or functionality. Running the TestSWD
  code on the JTAGulator will exercise the SWDHost module. Nothing
  needs to be connected to the JTAGulator headers when running the
  tests.
* There is currently only enough SWD support to issue a line reset,
  switch from JTAG to SWD mode, and read the IDCODE. This is enough
  to run a SWD base IDCODE scan. Additional functionality that could
  be added in the future might include:
  * Reading ROM tables.
  * Reading FLASH of ARM Cortex-M processors.
  * etc.
* Maximum speed (default speed used for scanning) of the SWDHost module
  at this time is 385kHz.