### PR TITLE
SWD Fixes

### DIFF
--- a/SWDHost.spin
+++ b/SWDHost.spin
@@ -173,7 +173,7 @@ PUB resetSwJtagAndReadIdCode(pValue)
     sendLineReset
     sendJtagToSwdSequence
     sendLineReset
-    idleBus(2)
+    idleBus(8)
     RETURN readDP(DP_IDCODE, pValue)
 
 
@@ -344,14 +344,14 @@ SwdRoutine
                 IF_E JMP #:ReadRegister
                 ' Get here if the command was OP_RESET.
                 
-:ResetCmd       ' Clock out 50 SWCLK pulses with SWDIO held high.
+:ResetCmd       ' Clock out 51 SWCLK pulses with SWDIO held high.
                 '  Do 32 bits first...
                 ABSNEG DataOut, #1
                 MOV BitCount, #32
                 CALL #ClockInOut
-                '  Do the remaining 18-bits.
+                '  Do the remaining 19-bits.
                 ABSNEG DataOut, #1
-                MOV BitCount, #18
+                MOV BitCount, #19
                 CALL #ClockInOut
                 JMP #:CmdDone
 


### PR DESCRIPTION
I code reviewed ARM's DAPLink sources tonight and noticed a few
differences between it and my implementation. This commit attempts to
bring it inline with their implementation:
* Increase idle at end of line reset to 8 clocks instead of 2. The
  spec indicates that it needs to be 2 or more but this was the second
  example of 8 being used instead that I have encountered.
* Increase the number of clock cycles with SWDIO held high from 50 to
  51 during line reset. Again the spec indicates 50 or more but DAPLink
  uses 51 so that might have been done based on real world problems
  they encountered.